### PR TITLE
Add the blahaj AUR packages to the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ They are built & published by our lovely [actions](https://github.com/GeopJr/BLA
 
 ### AUR
 
-Arch Linux users can download the [blahaj](https://aur.archlinux.org/packages/blahaj) (or the [blahaj-git](https://aur.archlinux.org/packages/blahaj-git)) AUR package.
+Arch Linux users can install the [blahaj](https://aur.archlinux.org/packages/blahaj) (or the [blahaj-git](https://aur.archlinux.org/packages/blahaj-git)) AUR package.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ You can download one of the statically-linked pre-built binaries from the [relea
 
 They are built & published by our lovely [actions](https://github.com/GeopJr/BLAHAJ/actions/workflows/release.yml).
 
+### AUR
+
+Arch Linux users can download the [blahaj](https://aur.archlinux.org/packages/blahaj) (or the [blahaj-git](https://aur.archlinux.org/packages/blahaj-git)) AUR package.
+
 ### Building
 
 #### Dependencies


### PR DESCRIPTION
Hi,

Thanks for your great work with `blahaj`!
I added it to the [Arch User Repository](https://wiki.archlinux.org/title/Arch_User_Repository), I hope it's okay for you :)

I submitted the [blahaj](https://aur.archlinux.org/packages/blahaj) AUR package (which is built from source against the latest tagged release, see the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=blahaj)), as well as the [blahaj-git](https://aur.archlinux.org/packages/blahaj-git) AUR package (which is built from source against the latest commit to the main branch, see the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=blahaj-git)).
I'm obviously down to maintain those two packages for the future releases of `blahaj` :wink: 

This PR aims to update the installation instructions accordingly.
I remain available if you need any additional information :smile: 

