### PR TITLE
Add DESTDIR var/param to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test_mt:
 	crystal spec --order random -Dpreview_mt 
 
 install:
-	install -D -m 0755 bin/blahaj $(PREFIX)/bin/blahaj
+	install -D -m 0755 bin/blahaj $(DESTDIR)$(PREFIX)/bin/blahaj
 
 uninstall:
-	rm -f $(PREFIX)/bin/blahaj
+	rm -f $(DESTDIR)$(PREFIX)/bin/blahaj


### PR DESCRIPTION
Hi,

This PR aims to add the *usual* `DESTDIR` var/param to the Makefile which would allow downstream (me :yum:) to make use of the `install` section properly in the AUR's PKGBUILDs like so: `make PREFIX=/usr DESTDIR="${pkgdir}" install`

This doesn't affect the current [BUILDING/Makefile](https://github.com/GeopJr/BLAHAJ#makefile) instructions :)