### PR TITLE
Add an option to select a random color with a command line flag

### DIFF
--- a/src/blahaj/option_parser.cr
+++ b/src/blahaj/option_parser.cr
@@ -60,6 +60,10 @@ module Blahaj
           @config.color = down_flag
         end
 
+        parser.on("-r", "--random", "Use a random color scheme") do
+          @config.color = COLORS.sample[0]
+        end
+
         parser.on("--flags", "List all available flags") do
           puts "Available flags/colors:\n".colorize(:light_blue)
           puts COLORS.keys.sort.map { |x|


### PR DESCRIPTION
This PR adds a new CLI flag that makes it easy to select a random color from the color schemes. 
I've never programmed in crystal before, however this code change is so small that I believe it should be no problem, but I'd be happy to be educated if there's a more efficient way to do this :)