### PR TITLE
Add transbian flag

### DIFF
--- a/data/colors.yaml
+++ b/data/colors.yaml
@@ -7,6 +7,13 @@ trans:
     - 5BCEFA
   alias:
     - transgender
+transbian:
+  color:
+    - 5BCEFA
+    - F5A9B8
+    - FFFFFF
+    - FF9A56
+    - A30262
 abrosexual:
   color:
     - 76CB93


### PR DESCRIPTION
This PR adds a transbian flag kind of based on the image from wikimedia commons on google search.
![image](https://github.com/user-attachments/assets/1c403f6b-0da3-43b2-b0e0-9beb5318018a)
